### PR TITLE
Fix installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For Alpha/Nightly builds please go to [Releases](https://github.com/hello-effici
 To use Homebrew-Cask you just need to have [Homebrew](https://brew.sh/) installed.
 
 ```bash
-brew cask install raven-reader
+brew install --cask raven-reader
 ```
 
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew in macOS. This is not a bug of this app, but readme needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103324148-76db7180-4a89-11eb-9af5-d7aeebdc243e.png)
