### PR TITLE
Allow playing videos in fullscreen

### DIFF
--- a/src/components/ArticleDetail.vue
+++ b/src/components/ArticleDetail.vue
@@ -46,6 +46,7 @@
                 <iframe
                   :src="article.media.url"
                   allowtransparency
+                  allowfullscreen
                 />
               </div>
             </vue-plyr>

--- a/src/components/ArticleDetail.vue
+++ b/src/components/ArticleDetail.vue
@@ -322,6 +322,15 @@ export default {
     border: 0;
   }
 
+  .plyr__poster {
+    display: none;
+  }
+
+  .plyr__control--overlaid,
+  .plyr__control--overlaid:hover {
+    background: transparent!important;
+}
+
   .col {
     padding-left: 0;
     padding-right: 0;


### PR DESCRIPTION
Videos wouldn't play in fullscreen (the resolution didn't change and there was a black border) - this pull request fixes that :)
I have also added styling so that YouTube videos have the default poster and the button doesn't clash.